### PR TITLE
Fix for issue #1

### DIFF
--- a/src/model.rs
+++ b/src/model.rs
@@ -124,7 +124,7 @@ pub struct DelayStat {
 impl From<&[u8]> for TaskStats {
     fn from(buf: &[u8]) -> Self {
         let mut inner_buf = [0u8; TASKSTATS_SIZE];
-        inner_buf.copy_from_slice(buf);
+        inner_buf.copy_from_slice(&buf[..TASKSTATS_SIZE]);
         let ts = unsafe { &*(inner_buf.as_ptr() as *const _ as *const taskstats) };
         TaskStats {
             tid: ts.ac_pid,


### PR DESCRIPTION
Sorry this is so late!

This is a workaround/fix for issue #1 as described [here](https://github.com/kawamuray/linux-taskstats-rs/issues/1#issuecomment-930077708). Very simple fix - only copy the part of the buffer we care about.