### PR TITLE
Use feature control to allow using the library without the binary dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,14 +15,24 @@ exclude = [
     "docker-build/*",
 ]
 
+[[bin]]
+name = "taskstats"
+path = "src/bin/taskstats/main.rs"
+required-features = ["executable"]
+
 [dependencies]
 libc = "0.2"
 netlink-sys = "0.2"
 thiserror = "1.0.16"
 log = "0.4.8"
-env_logger = "0.7.1"
-prettytable-rs = "0.8.0"
-clap = "2.33.1"
+env_logger = { version = "0.7.1", optional = true }
+prettytable-rs = { version = "0.8.0", optional = true }
+clap = { version = "2.33.1", optional = true }
+
+[features]
+default = ["executable"]
+executable = ["env_logger", "clap", "format"]
+format = ["prettytable-rs"]
 
 [build-dependencies]
 bindgen = "0.53.1"

--- a/src/bin/taskstats/cmd.rs
+++ b/src/bin/taskstats/cmd.rs
@@ -1,5 +1,5 @@
-use crate::format::{HeaderFormat, Printer};
-use crate::Client;
+use linux_taskstats::format::{HeaderFormat, Printer};
+use linux_taskstats::Client;
 use env_logger;
 use std::io;
 

--- a/src/bin/taskstats/main.rs
+++ b/src/bin/taskstats/main.rs
@@ -1,7 +1,8 @@
 use clap::{App, Arg};
-use linux_taskstats::cmd;
 use linux_taskstats::format::DefaultHeaderFormat;
 use std::process;
+
+mod cmd;
 
 fn main() {
     let matches = App::new("A command line interface to Linux taskstats")

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,7 +4,7 @@
 
 #[allow(dead_code)]
 mod c_headers;
-pub mod cmd;
+#[cfg(feature = "format")]
 pub mod format;
 mod model;
 pub(crate) mod netlink;


### PR DESCRIPTION
When using the library, it is now possible for users to use `default-features = false` and code for the binary and its dependencies will not be included downstream.

The module `format` is now public because it is used in the binary, but its tests also require `model`, which is private to the lib.

An alternative to this approach would be to have no features enabled by default, in which case instead of `cargo run`, one must write `cargo run --features=executable`.