### PR TITLE
Updated bindgen, log, and env_logger so that a newer version of regex…

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,8 +24,8 @@ required-features = ["executable"]
 libc = "0.2"
 netlink-sys = "0.8.2"
 thiserror = "1.0.30"
-log = "0.4.16"
-env_logger = { version = "0.9.0", optional = true }
+log = "0.4.17"
+env_logger = { version = "0.9.1", optional = true }
 prettytable-rs = { version = "0.8.0", optional = true }
 clap = { version = "3.1.8", optional = true }
 
@@ -35,4 +35,4 @@ executable = ["env_logger", "clap", "format"]
 format = ["prettytable-rs"]
 
 [build-dependencies]
-bindgen = "0.59.2"
+bindgen = "0.61.0"


### PR DESCRIPTION
… would be used fixing a vulnerability.

Specifically this one: https://blog.rust-lang.org/2022/03/08/cve-2022-24713.html