### PR TITLE
Upgrade dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,13 +21,13 @@ path = "src/bin/taskstats/main.rs"
 required-features = ["executable"]
 
 [dependencies]
-libc = "0.2"
-netlink-sys = "0.8.2"
-thiserror = "1.0.30"
+libc = "0.2.139"
+netlink-sys = "0.8.3"
+thiserror = "1.0.38"
 log = "0.4.17"
-env_logger = { version = "0.9.1", optional = true }
-prettytable-rs = { version = "0.8.0", optional = true }
-clap = { version = "3.1.8", optional = true }
+env_logger = { version = "0.10.0", optional = true }
+prettytable-rs = { version = "0.10.0", optional = true }
+clap = { version = "4.1.1", optional = true }
 
 [features]
 default = ["executable"]
@@ -35,4 +35,4 @@ executable = ["env_logger", "clap", "format"]
 format = ["prettytable-rs"]
 
 [build-dependencies]
-bindgen = "0.61.0"
+bindgen = "0.63.0"

--- a/src/bin/taskstats/main.rs
+++ b/src/bin/taskstats/main.rs
@@ -1,32 +1,40 @@
-use clap::{Arg, Command};
+use clap::{Arg, ArgAction, Command};
 use linux_taskstats::format::DefaultHeaderFormat;
-use std::process;
 
 mod cmd;
 
 fn main() {
     let matches = Command::new("A command line interface to Linux taskstats")
-        .arg(Arg::new("verbose").short('v').long("verbose"))
-        .arg(Arg::new("show-delays").short('d').long("delay"))
-        .arg(Arg::new("TIDS").index(1).multiple_values(true))
+        .arg(
+            Arg::new("verbose")
+                .short('v')
+                .long("verfbose")
+                .action(ArgAction::SetTrue),
+        )
+        .arg(
+            Arg::new("show-delays")
+                .short('d')
+                .long("delay")
+                .action(ArgAction::SetTrue),
+        )
+        .arg(
+            Arg::new("TIDS")
+                .index(1)
+                .num_args(1..)
+                .action(ArgAction::Append),
+        )
         .get_matches();
 
     let tids: Vec<_> = matches
-        .values_of("TIDS")
+        .get_many::<u32>("TIDS")
         .unwrap()
-        .map(|v| match v.parse::<u32>() {
-            Ok(pid) => pid,
-            Err(_) => {
-                eprintln!("Invalid PID: {}", v);
-                process::exit(1);
-            }
-        })
+        .map(|x| *x)
         .collect();
 
     let config = cmd::Config {
         tids,
-        verbose: matches.is_present("verbose"),
-        show_delays: matches.is_present("show-delays"),
+        verbose: matches.contains_id("verbose"),
+        show_delays: matches.contains_id("show-delays"),
         header_format: DefaultHeaderFormat::new(),
     };
     cmd::taskstats_main(config);

--- a/src/format.rs
+++ b/src/format.rs
@@ -1,5 +1,5 @@
 use crate::TaskStats;
-use prettytable::{self as ptable, cell, row};
+use prettytable::{self as ptable, row};
 use std::io::{self, Write};
 
 pub trait HeaderFormat {


### PR DESCRIPTION
    Upgrading env_logger v0.9.1 -> v0.10.0     
    Upgrading libc v0.2 -> v0.2.139                                                                   
    Upgrading prettytable-rs v0.8.0 -> v0.10.0
    Upgrading clap v3.1.8 -> v4.1.1 
    Upgrading netlink-sys v0.8.2 -> v0.8.3
    Upgrading thiserror v1.0.30 -> v1.0.38
    Upgrading bindgen v0.61.0 -> v0.63.0
