### PR TITLE
Update Bindgen dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,4 +35,4 @@ executable = ["env_logger", "clap", "format"]
 format = ["prettytable-rs"]
 
 [build-dependencies]
-bindgen = "0.63.0"
+bindgen = "0.69.0"

--- a/build.rs
+++ b/build.rs
@@ -20,7 +20,7 @@ fn main() {
         .header("wrapper.h")
         // Tell cargo to invalidate the built crate whenever any of the
         // included header files changed.
-        .parse_callbacks(Box::new(bindgen::CargoCallbacks))
+        .parse_callbacks(Box::new(bindgen::CargoCallbacks::new()))
         // Finish the builder and generate the bindings.
         .generate()
         // Unwrap the Result and panic on failure.


### PR DESCRIPTION
This PR updates `bindgen` to  `0.69.4`. There is a [security issue](https://rustsec.org/advisories/RUSTSEC-2024-0006) in `shlex` version `1.1.0` which is a dependency of `bindgen` this PR fixes that issue. 

Additionally, the newer version of bindgen deprecated the use of the constant `bindgen::CargoCallbacks`. So that is replaced as recommended with `CargoCallbacks::new()`.

Code passed all tests, but with 43 warnings of `dereferencing a null pointer`, which remains unchanged from the `master` branch.

```
running 24 tests
test c_headers::bindgen_test_layout___kernel_fd_set ... ok
test c_headers::bindgen_test_layout___kernel_fsid_t ... ok
test c_headers::bindgen_test_layout___kernel_sockaddr_storage ... ok
test c_headers::bindgen_test_layout_genlmsghdr ... ok
test c_headers::bindgen_test_layout_nl_mmap_hdr ... ok
test c_headers::bindgen_test_layout_nl_mmap_req ... ok
test c_headers::bindgen_test_layout_nl_pktinfo ... ok
test c_headers::bindgen_test_layout_nlattr ... ok
test c_headers::bindgen_test_layout_nla_bitfield32 ... ok
test c_headers::bindgen_test_layout_nlmsgerr ... ok
test c_headers::bindgen_test_layout_nlmsghdr ... ok
test c_headers::bindgen_test_layout_sockaddr_nl ... ok
test c_headers::bindgen_test_layout_sysinfo ... ok
test c_headers::bindgen_test_layout_taskstats ... ok
test netlink::tests::test_gennlmsg_payload ... ok
test format::tests::test_print_full ... ok
test netlink::tests::test_nlattr_payload ... ok
test netlink::tests::test_nlpayload ... ok
test format::tests::test_print_delay_lines ... ok
test format::tests::test_print_summary_lines ... ok
test netlink::tests::test_nlpayload_nlattrs ... ok
test tests::test_struct_taskstats_alignment ... ok
test netlink::tests::test_send_cmd ... ok
test netlink::tests::test_recv_response ... ok

test result: ok. 24 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

     Running unittests src/bin/taskstats/main.rs (target/debug/deps/taskstats-dae3fa9258528d3d)

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

   Doc-tests linux-taskstats

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
```