### PR TITLE
Add API for monitoring exited tasks

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ required-features = ["executable"]
 
 [dependencies]
 libc = "0.2.139"
-netlink-sys = "0.8.3"
+netlink-sys = "0.8.6"
 thiserror = "1.0.38"
 log = "0.4.17"
 env_logger = { version = "0.10.0", optional = true }

--- a/src/netlink.rs
+++ b/src/netlink.rs
@@ -105,6 +105,14 @@ impl Netlink<nl::Socket> {
             mypid: process::id(),
         })
     }
+
+    pub fn set_rx_buf_sz<T>(&self, payload: T) -> Result<()> {
+        self.sock.set_rx_buf_sz(payload).map_err(|err| err.into())
+    }
+
+    pub fn get_rx_buf_sz(&self) -> Result<usize> {
+        self.sock.get_rx_buf_sz().map_err(|err| err.into())
+    }
 }
 
 impl<S: NlSocket> Netlink<S> {


### PR DESCRIPTION
To be compliant with the taskstats docs,
also added methods to adjust the RX socket buffer